### PR TITLE
fix broken dependency function

### DIFF
--- a/polyxdr/parser.py
+++ b/polyxdr/parser.py
@@ -155,7 +155,7 @@ class Parser:
           g(kw("bool")) + identifier | \
           g(resolved_type_specifier) + identifier + s(":") + numeric_literal
 
-      conversion_expr = P.operatorPrecedence( kw("val") | \
+      conversion_expr = P.infixNotation( kw("val") | \
             P.pyparsing_common.fnumber, \
           [(P.oneOf('+ -'), 1, P.opAssoc.RIGHT), \
            (P.oneOf('* /'), 2, P.opAssoc.LEFT), \


### PR DESCRIPTION
function named operatorPrecedence renamed to infixNotation in newest version of pyparser library