### PR TITLE
add version specifier for pyparsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ config = {
     'url': 'http://github.com/PolySat/libproc',
     'author_email': 'cubesat@cubesat.org',
     'version': '0.1',
-    'install_requires': ['nose', 'tenjin', 'pyparsing'],
+    'install_requires': ['nose', 'tenjin', 'pyparsing<=2.4'],
     'packages': ['polyxdr', 'polyxdr/backends', 'polyxdr/backends/xp', 'polyxdr/backends/libproc', 'polyxdr/backends/telem-dict'],
     'package_data': {'polyxdr': ['backends/libproc/templates/*.c', 'backends/libproc/templates/*.h', 'backends/xp/templates/*.xp', 'backends/telem-dict/templates/s*']},
     'scripts': ['poly-xdrgen']


### PR DESCRIPTION
setup pulled from pyparsing v3.0 from pyparsing's pre-release branch for me for some reason

that broke a function causing the polyxdr install to fail, adding a version specifier ensures the correct version of pyparsing is installed